### PR TITLE
feat: Add datetime object validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,18 @@ Cron('* 1 6 * 1-5') > Cron('* 1 6 * 1-4') # True
 ## About seconds repeats
 Cron-converter is NOT able to do second repetition crontabs form.
 
+## About datetime objects validation
+Cron can also validate datetime objects (datetime and date).
+```python
+Cron("* * 10 * *").validate(datetime(2022, 1, 10, 1, 9)) # True
+Cron("* * 12 * *").validate(datetime(2022, 1, 10, 1, 9)) # False
+```
+
+A datetime object can also be validated with the `in` operator
+```python
+datetime(2024, 3, 19, 15, 55) in Cron('*/5 9-17/2 * 1-3 1-5') # True
+```
+
 ## Develop & Tests
 ```bash
 git clone https://github.com/Sonic0/cron-converter

--- a/cron_converter/cron.py
+++ b/cron_converter/cron.py
@@ -44,7 +44,7 @@ class Cron:
         """
         return all(part == other_part for part, other_part in zip(self.parts, other.parts))
 
-    def __contains__(self, item: datetime | date) -> bool:
+    def __contains__(self, item: Union[datetime, date]) -> bool:
         return self.validate(item)
 
     def from_string(self, cron_string: str) -> None:
@@ -116,7 +116,7 @@ class Cron:
         """
         return Seeker(self, start_date, timezone_str)
 
-    def validate(self, date_time_obj: datetime | date) -> bool:
+    def validate(self, date_time_obj: Union[datetime, date]) -> bool:
         """Returns True if the object passed is within the Cron rule.
 
         :param date_time_obj: A datetime or date object

--- a/cron_converter/cron.py
+++ b/cron_converter/cron.py
@@ -44,6 +44,9 @@ class Cron:
         """
         return all(part == other_part for part, other_part in zip(self.parts, other.parts))
 
+    def __contains__(self, item: datetime | date) -> bool:
+        return self.validate(item)
+
     def from_string(self, cron_string: str) -> None:
         """Parses a cron string (minutes - hours - days - months - weekday)
 
@@ -113,7 +116,7 @@ class Cron:
         """
         return Seeker(self, start_date, timezone_str)
 
-    def is_valid(self, date_time_obj: datetime | date) -> bool:
+    def validate(self, date_time_obj: datetime | date) -> bool:
         """Returns True if the object passed is within the Cron rule.
 
         :param date_time_obj: A datetime or date object
@@ -129,6 +132,3 @@ class Cron:
                 valid.append(True)
 
         return all(valid)
-
-    def __contains__(self, item: datetime | date) -> bool:
-        return self.is_valid(item)

--- a/cron_converter/cron.py
+++ b/cron_converter/cron.py
@@ -1,11 +1,11 @@
-from .sub_modules.part import Part
-from .sub_modules.units import units
-from .sub_modules.seeker import Seeker
-
-from datetime import datetime
+from datetime import datetime, date
 from functools import total_ordering
-
 from typing import Optional, List, Union
+
+from .sub_modules.part import Part
+from .sub_modules.seeker import Seeker
+from .sub_modules.units import units
+from .sub_modules.utils import to_parts
 
 
 @total_ordering
@@ -112,3 +112,23 @@ class Cron:
         :return: A schedule iterator.
         """
         return Seeker(self, start_date, timezone_str)
+
+    def is_valid(self, date_time_obj: datetime | date) -> bool:
+        """Returns True if the object passed is within the Cron rule.
+
+        :param date_time_obj: A datetime or date object
+
+        :return: True if the object passed is within the Cron Rule.
+        """
+
+        valid = []
+        for cron_part, d_par in zip(self.parts, to_parts(date_time_obj)):
+            if d_par is not None:
+                valid.append(d_par in cron_part.to_list())
+            else:
+                valid.append(True)
+
+        return all(valid)
+
+    def __contains__(self, item: datetime | date) -> bool:
+        return self.is_valid(item)

--- a/cron_converter/sub_modules/utils.py
+++ b/cron_converter/sub_modules/utils.py
@@ -1,7 +1,8 @@
 import datetime
+from typing import Union
 
 
-def to_parts(d: datetime.datetime | datetime.date) -> list[int | None]:
+def to_parts(d: Union[datetime.datetime, datetime.date]) -> list[Union[int, None]]:
     minute = None
     hour = None
     day = d.day

--- a/cron_converter/sub_modules/utils.py
+++ b/cron_converter/sub_modules/utils.py
@@ -1,0 +1,14 @@
+import datetime
+
+
+def to_parts(d: datetime.datetime | datetime.date) -> list[int | None]:
+    minute = None
+    hour = None
+    day = d.day
+    month = d.month
+    dayofweek = d.weekday()
+
+    if isinstance(d, datetime.datetime):
+        minute = d.minute
+        hour = d.hour
+    return [minute, hour, day, month, dayofweek]

--- a/cron_converter/sub_modules/utils.py
+++ b/cron_converter/sub_modules/utils.py
@@ -1,8 +1,8 @@
 import datetime
-from typing import Union
+from typing import Union, List
 
 
-def to_parts(d: Union[datetime.datetime, datetime.date]) -> list[Union[int, None]]:
+def to_parts(d: Union[datetime.datetime, datetime.date]) -> List[Union[int, None]]:
     minute = None
     hour = None
     day = d.day

--- a/tests/unit/tests_cron.py
+++ b/tests/unit/tests_cron.py
@@ -65,16 +65,17 @@ class CronTest(unittest.TestCase):
         self.assertTrue(Cron('* 1 6 1 *') > Cron('* 1 6 1 1-5'))
 
     def test_datetime_is_valid_cron(self):
-        self.assertTrue(Cron('* * * * *').is_valid(datetime.now()))
-        self.assertTrue(Cron('10 * * * *').is_valid(datetime(2022, 1, 1, 9, 10)))
-        self.assertTrue(Cron('* 10 * * *').is_valid(datetime(2022, 1, 1, 10, 9)))
-        self.assertTrue(Cron('* * 10 * *').is_valid(datetime(2022, 1, 10, 1, 9)))
-        self.assertTrue(Cron('* * * 10 *').is_valid(datetime(2022, 10, 1, 1, 9)))
+        self.assertTrue(Cron('* * * * *').validate(datetime.now()))
+        self.assertTrue(Cron('10 * * * *').validate(datetime(2022, 1, 1, 9, 10)))
+        self.assertTrue(Cron('* 10 * * *').validate(datetime(2022, 1, 1, 10, 9)))
+        self.assertTrue(Cron('* * 10 * *').validate(datetime(2022, 1, 10, 1, 9)))
+        self.assertTrue(Cron('* * * 10 *').validate(datetime(2022, 10, 1, 1, 9)))
         # 2024-03-19 is a Tuesday
-        self.assertTrue(Cron('* * * * 1').is_valid(datetime(2024, 3, 19, 1, 9)))
-        self.assertTrue(Cron('9 1 19 3 1').is_valid(datetime(2024, 3, 19, 1, 9)))
-        self.assertTrue(Cron('* 1 19 3 1').is_valid(datetime(2024, 3, 19, 1, 55)))
-        self.assertTrue(Cron('*/5 9-17/2 * 1-3 1-5').is_valid(datetime(2024, 3, 19, 15, 55)))
+        self.assertTrue(Cron('* * * * 1').validate(datetime(2024, 3, 19, 1, 9)))
+        self.assertTrue(Cron('9 1 19 3 1').validate(datetime(2024, 3, 19, 1, 9)))
+        self.assertTrue(Cron('* 1 19 3 1').validate(datetime(2024, 3, 19, 1, 55)))
+        self.assertTrue(
+            Cron('*/5 9-17/2 * 1-3 1-5').validate(datetime(2024, 3, 19, 15, 55)))
 
     def test_date_object_in_cron(self):
         self.assertTrue((date.today()) in Cron('* * * * *'))

--- a/tests/unit/tests_cron.py
+++ b/tests/unit/tests_cron.py
@@ -74,6 +74,7 @@ class CronTest(unittest.TestCase):
         self.assertTrue(Cron('* * * * 1').is_valid(datetime(2024, 3, 19, 1, 9)))
         self.assertTrue(Cron('9 1 19 3 1').is_valid(datetime(2024, 3, 19, 1, 9)))
         self.assertTrue(Cron('* 1 19 3 1').is_valid(datetime(2024, 3, 19, 1, 55)))
+        self.assertTrue(Cron('*/5 9-17/2 * 1-3 1-5').is_valid(datetime(2024, 3, 19, 15, 55)))
 
     def test_date_object_in_cron(self):
         self.assertTrue((date.today()) in Cron('* * * * *'))
@@ -85,3 +86,4 @@ class CronTest(unittest.TestCase):
         self.assertTrue((date(2024, 3, 19)) in Cron('9 1 19 3 1'))
         self.assertTrue((datetime(2024, 3, 19, 1, 55)) in Cron('* 1 19 3 1'))
         self.assertFalse((datetime(2024, 4, 19, 1, 55)) in Cron('* 1 19 3 1'))
+        self.assertTrue((datetime(2024, 3, 19, 15, 55) in Cron('*/5 9-17/2 * 1-3 1-5')))

--- a/tests/unit/tests_cron.py
+++ b/tests/unit/tests_cron.py
@@ -1,4 +1,5 @@
 import unittest
+from datetime import datetime, date
 
 from cron_converter.cron import Cron
 
@@ -62,3 +63,25 @@ class CronTest(unittest.TestCase):
     def test_gt_weekday(self):
         self.assertTrue(Cron('* 1 6 * 1-5') > Cron('* 1 6 * 1-4'))
         self.assertTrue(Cron('* 1 6 1 *') > Cron('* 1 6 1 1-5'))
+
+    def test_datetime_is_valid_cron(self):
+        self.assertTrue(Cron('* * * * *').is_valid(datetime.now()))
+        self.assertTrue(Cron('10 * * * *').is_valid(datetime(2022, 1, 1, 9, 10)))
+        self.assertTrue(Cron('* 10 * * *').is_valid(datetime(2022, 1, 1, 10, 9)))
+        self.assertTrue(Cron('* * 10 * *').is_valid(datetime(2022, 1, 10, 1, 9)))
+        self.assertTrue(Cron('* * * 10 *').is_valid(datetime(2022, 10, 1, 1, 9)))
+        # 2024-03-19 is a Tuesday
+        self.assertTrue(Cron('* * * * 1').is_valid(datetime(2024, 3, 19, 1, 9)))
+        self.assertTrue(Cron('9 1 19 3 1').is_valid(datetime(2024, 3, 19, 1, 9)))
+        self.assertTrue(Cron('* 1 19 3 1').is_valid(datetime(2024, 3, 19, 1, 55)))
+
+    def test_date_object_in_cron(self):
+        self.assertTrue((date.today()) in Cron('* * * * *'))
+        self.assertTrue((datetime(2022, 1, 1, 1, 10)) in Cron('10 * * * *'))
+        self.assertFalse((datetime(2022, 1, 1)) in Cron('10 * * * *'))
+        self.assertTrue(date(2022, 1, 1) in (Cron('* 10 * * *')))
+        # 2024-03-19 is a Tuesday
+        self.assertTrue((date(2024, 3, 19)) in Cron('* * * * 1'))
+        self.assertTrue((date(2024, 3, 19)) in Cron('9 1 19 3 1'))
+        self.assertTrue((datetime(2024, 3, 19, 1, 55)) in Cron('* 1 19 3 1'))
+        self.assertFalse((datetime(2024, 4, 19, 1, 55)) in Cron('* 1 19 3 1'))


### PR DESCRIPTION
This PR adds the ability to compare datetime objects to Cron 

For example:

```python
>>> Cron("* * 10 * *").is_valid(datetime(2022, 1, 10, 1, 9))
True
```

or using the `in` operator

```python
>>> datetime(2024, 3, 19, 15, 55) in Cron('*/5 9-17/2 * 1-3 1-5')
True
```

I thought this could be useful when working with datetimes object and need some sort of Cron validation
