### PR TITLE
fix: test_timezone should not compare utcoffset across DST boundaries

### DIFF
--- a/tests/integration/tests_cron_seeker.py
+++ b/tests/integration/tests_cron_seeker.py
@@ -58,6 +58,16 @@ class SeekerTest(unittest.TestCase):
                 cron = Cron()
                 cron.from_string(valid_schedule['schedule'])
                 schedule = cron.schedule(timezone_str=valid_schedule['timezone'])
-                self.assertTrue(schedule.next().utcoffset().seconds ==
-                                datetime.now(tz=tz.gettz(valid_schedule['timezone'])).utcoffset().seconds,
-                                'Timezones does not match')
+                next_run = schedule.next()
+
+                self.assertIsNotNone(next_run.tzinfo,
+                                   f'Scheduled datetime should have timezone info for {valid_schedule["timezone"]}')
+
+                expected_tz = tz.gettz(valid_schedule['timezone'])
+                self.assertEqual(str(next_run.tzinfo), str(expected_tz),
+                               f'Timezone name does not match for {valid_schedule["timezone"]}')
+
+                reference_dt = datetime(next_run.year, next_run.month, next_run.day,
+                                       next_run.hour, next_run.minute, 0, 0, tzinfo=expected_tz)
+                self.assertEqual(next_run.utcoffset(), reference_dt.utcoffset(),
+                               f'UTC offset does not match for {valid_schedule["timezone"]} at {next_run}')


### PR DESCRIPTION
Fixes #32

I've also tested the integration test suite for each quarter from 2025→2030 to look for any future surprises.

```console
$ for year in {2025..2030}; do for date in $year-01-15 $year-04-15 $year-07-15 $year-10-15; do echo -n "Testing $date ... " && faketime "$date 10:00:00" nix-shell -p 'python3.withPackages(ps: [ 
  ps.python-dateutil ])' --run "PYTHONPATH=. python3 -m unittest discover -s tests/integration -q" && echo "OK"; done; done
Testing 2025-01-15 ... ----------------------------------------------------------------------
Ran 15 tests in 0.008s

OK
OK
Testing 2025-04-15 ... ----------------------------------------------------------------------
Ran 15 tests in 0.008s

…

Testing 2030-07-15 ... ----------------------------------------------------------------------
Ran 15 tests in 0.008s

OK
OK
Testing 2030-10-15 ... ----------------------------------------------------------------------
Ran 15 tests in 0.008s

OK
OK
```